### PR TITLE
Add support for Sprockets 3.x

### DIFF
--- a/lib/js_image_paths/engine.rb
+++ b/lib/js_image_paths/engine.rb
@@ -4,7 +4,8 @@ module JsImagePaths
     isolate_namespace(JsImagePaths)
 
     initializer('js_image_paths.compile', after: 'sprockets.environment') do |application|
-      application.assets.register_preprocessor('application/javascript', :'js_image_path.compile') do |context, data|
+      sprockets_env = application.assets || Sprockets
+      sprockets_env.register_preprocessor('application/javascript', :'js_image_path.compile') do |context, data|
         if context.logical_path == 'js_image_paths'
           JsImagePaths::Generator.context = context
         end


### PR DESCRIPTION
I found the fix in the [reactjs repo](https://github.com/reactjs/react-rails/pull/322) and did a quick test with diaspora* using Sprockets 3.5.2 as well as 2.12.4. Without this fix the server didn't start at all.