### PR TITLE
Add sprockets 4 support and allow rails 6+7

### DIFF
--- a/js_image_paths.gemspec
+++ b/js_image_paths.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "rails", ">= 4.0", "< 6.0"
+  spec.add_dependency "rails", ">= 4.0", "< 8.0"
   spec.add_dependency "sprockets", ">= 3.0.0"
   spec.add_development_dependency "bundler", "~> 1.10"
   spec.add_development_dependency "rake", "~> 10.0"

--- a/lib/js_image_paths.rb
+++ b/lib/js_image_paths.rb
@@ -1,5 +1,6 @@
 require "js_image_paths/version"
 require "js_image_paths/engine"
 require "js_image_paths/generator"
+require "js_image_paths/processor"
 module JsImagePaths
 end

--- a/lib/js_image_paths/engine.rb
+++ b/lib/js_image_paths/engine.rb
@@ -3,15 +3,12 @@ module JsImagePaths
 
     isolate_namespace(JsImagePaths)
 
-    initializer('js_image_paths.compile', after: 'sprockets.environment') do |application|
+    initializer('js_image_paths.compile', after: :engines_blank_point, before: :finisher_hook) do |application|
+      file_type = 'application/javascript'
+      file_type += '+ruby' if Gem::Version.new(::Sprockets::VERSION).segments[0] >= 4
+
       sprockets_env = application.assets || Sprockets
-      sprockets_env.register_preprocessor('application/javascript', :'js_image_path.compile') do |input|
-        context = input[:environment].context_class.new(input)
-        if context.logical_path == 'js_image_paths'
-          JsImagePaths::Generator.context = context
-        end
-        {data: input[:data]}
-      end
+      sprockets_env.register_preprocessor(file_type, JsImagePaths::Processor)
     end
   end
 end

--- a/lib/js_image_paths/generator.rb
+++ b/lib/js_image_paths/generator.rb
@@ -8,11 +8,15 @@ module JsImagePaths
 
     def self.image_hash
       context.environment.each_file.each_with_object({}) do |path, images|
-        next unless path.include?('images')
+        next unless path.start_with?(app_images_path)
 
         asset = context.environment.find_asset(path)
         images[asset.logical_path] = context.asset_path(asset.logical_path)
       end
+    end
+
+    def self.app_images_path
+      @app_images_path ||= Rails.root.join('app/assets/images').to_s
     end
   end
 end

--- a/lib/js_image_paths/generator.rb
+++ b/lib/js_image_paths/generator.rb
@@ -7,9 +7,11 @@ module JsImagePaths
     end
 
     def self.image_hash
-      images = context.environment.each_logical_path(->(_, path) { path.include? "images" })
-      images.each_with_object({}) do |path, images|
-        images[path] = context.asset_path(path)
+      context.environment.each_file.each_with_object({}) do |path, images|
+        next unless path.include?('images')
+
+        asset = context.environment.find_asset(path)
+        images[asset.logical_path] = context.asset_path(asset.logical_path)
       end
     end
   end

--- a/lib/js_image_paths/processor.rb
+++ b/lib/js_image_paths/processor.rb
@@ -1,0 +1,9 @@
+module JsImagePaths
+  module Processor
+    def self.call(input)
+      JsImagePaths::Generator.context = input[:environment].context_class.new(input) if input[:name] == 'js_image_paths'
+
+      {data: input[:data]}
+    end
+  end
+end


### PR DESCRIPTION
This fixes compatibility with sprockets 4 and allows rails 6 and 7 in the gemspec.

I also fixed another issue where it would end up in an endless nested loop (`SystemStackError (stack level too deep)`) if you have `images` somewhere in your path, because it then tries to add itself to itself (and it also adds everything else, because suddenly all assets are an "image"). To fix that I now only add images from the app itself (`app/assets/images`) to the image paths. This works for what we need it in diaspora, but it's technically a breaking change. A better solution maybe would be, to make it configurable which paths it adds, but I'm not sure if that's worth it?

fixes #6 